### PR TITLE
test: add regression tests for redstone wiring and propagation

### DIFF
--- a/server/block/note_redstone_test.go
+++ b/server/block/note_redstone_test.go
@@ -1,0 +1,54 @@
+package block
+
+import (
+	"fmt"
+	"testing"
+	_ "unsafe"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+//go:linkname finaliseBlockRegistryForNoteRedstone github.com/df-mc/dragonfly/server/world.finaliseBlockRegistry
+func finaliseBlockRegistryForNoteRedstone()
+
+func init() {
+	finaliseBlockRegistryForNoteRedstone()
+}
+
+func testNoteRedstoneTx(t *testing.T, f func(tx *world.Tx) error) {
+	t.Helper()
+
+	w := world.New()
+	var txErr error
+	<-w.Exec(func(tx *world.Tx) {
+		txErr = f(tx)
+	})
+	if err := w.Close(); err != nil {
+		t.Fatalf("close world: %v", err)
+	}
+	if txErr != nil {
+		t.Fatal(txErr)
+	}
+}
+
+func TestPoweredNoteBlockUpdatesAdjacentNoteBlocks(t *testing.T) {
+	testNoteRedstoneTx(t, func(tx *world.Tx) error {
+		leverPos := cube.Pos{0, 1, 0}
+		firstNotePos := leverPos.Side(cube.FaceEast)
+		secondNotePos := firstNotePos.Side(cube.FaceEast)
+
+		tx.SetBlock(leverPos, Lever{Powered: true, Facing: cube.FaceWest}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(firstNotePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(secondNotePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		updateRedstone(firstNotePos, tx)
+		if note := tx.Block(firstNotePos).(Note); !note.Powered {
+			return fmt.Errorf("first note block was not powered")
+		}
+		if note := tx.Block(secondNotePos).(Note); !note.Powered {
+			return fmt.Errorf("second note block was not updated through powered note block")
+		}
+		return nil
+	})
+}

--- a/server/block/redstone_regression_test.go
+++ b/server/block/redstone_regression_test.go
@@ -1,0 +1,458 @@
+package block
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	_ "unsafe"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+//go:linkname finaliseBlockRegistry github.com/df-mc/dragonfly/server/world.finaliseBlockRegistry
+func finaliseBlockRegistry()
+
+func TestMain(m *testing.M) {
+	finaliseBlockRegistry()
+	os.Exit(m.Run())
+}
+
+func testRedstoneTx(t *testing.T, f func(tx *world.Tx) error) {
+	t.Helper()
+
+	w := world.New()
+	var txErr error
+	<-w.Exec(func(tx *world.Tx) {
+		txErr = f(tx)
+	})
+	if err := w.Close(); err != nil {
+		t.Fatalf("close world: %v", err)
+	}
+	if txErr != nil {
+		t.Fatal(txErr)
+	}
+}
+
+func TestUnconnectedRedstoneWirePowersHorizontalMechanisms(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		wirePos := cube.Pos{0, 1, 0}
+		notePos := wirePos.Side(cube.FaceEast)
+
+		tx.SetBlock(wirePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, nil)
+
+		Note{}.RedstoneUpdate(notePos, tx)
+		if note := tx.Block(notePos).(Note); !note.Powered {
+			return fmt.Errorf("note block next to unconnected powered dust was not powered")
+		}
+		return nil
+	})
+}
+
+func TestPoweredSolidBlockPropagatesRedstoneUpdates(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		torchPos := cube.Pos{0, 1, 0}
+		stonePos := torchPos.Side(cube.FaceUp)
+		notePos := stonePos.Side(cube.FaceEast)
+
+		tx.SetBlock(stonePos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(torchPos, RedstoneTorch{Facing: cube.FaceDown, Lit: true}, &world.SetOpts{DisableBlockUpdates: true})
+
+		updateAroundRedstone(torchPos, tx)
+		if note := tx.Block(notePos).(Note); !note.Powered {
+			return fmt.Errorf("note block beside indirectly powered stone was not updated")
+		}
+		return nil
+	})
+}
+
+func TestWeaklyPoweredSolidBlockPowersAdjacentMechanism(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		leverPos := cube.Pos{0, 1, 0}
+		stonePos := leverPos.Side(cube.FaceEast)
+		notePos := stonePos.Side(cube.FaceEast)
+
+		tx.SetBlock(leverPos, Lever{Powered: true, Facing: cube.FaceWest}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(stonePos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		Note{}.RedstoneUpdate(notePos, tx)
+		if note := tx.Block(notePos).(Note); !note.Powered {
+			return fmt.Errorf("note block was not powered through a weakly powered solid block")
+		}
+		return nil
+	})
+}
+
+func TestRedstoneDustPowersMechanismThroughSolidBlock(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		wirePos := cube.Pos{0, 1, 0}
+		stonePos := wirePos.Side(cube.FaceEast)
+		notePos := stonePos.Side(cube.FaceEast)
+
+		tx.SetBlock(wirePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(stonePos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		Note{}.RedstoneUpdate(notePos, tx)
+		if note := tx.Block(notePos).(Note); !note.Powered {
+			return fmt.Errorf("note block was not powered through a dust-powered solid block")
+		}
+		return nil
+	})
+}
+
+func TestRedstoneBlockDoesNotPowerMechanismThroughSolidBlock(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		blockPos := cube.Pos{0, 1, 0}
+		stonePos := blockPos.Side(cube.FaceEast)
+		notePos := stonePos.Side(cube.FaceEast)
+
+		tx.SetBlock(blockPos, RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(stonePos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		Note{}.RedstoneUpdate(notePos, tx)
+		if note := tx.Block(notePos).(Note); note.Powered {
+			return fmt.Errorf("note block was incorrectly powered through a redstone block and solid block")
+		}
+		return nil
+	})
+}
+
+func TestGlowstoneDoesNotConductRedstonePower(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		leverPos := cube.Pos{0, 1, 0}
+		glowstonePos := leverPos.Side(cube.FaceEast)
+		notePos := glowstonePos.Side(cube.FaceEast)
+
+		tx.SetBlock(leverPos, Lever{Powered: true, Facing: cube.FaceWest}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(glowstonePos, Glowstone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		Note{}.RedstoneUpdate(notePos, tx)
+		if note := tx.Block(notePos).(Note); note.Powered {
+			return fmt.Errorf("note block was powered through glowstone")
+		}
+		return nil
+	})
+}
+
+func TestGlowstoneBlocksSkylight(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		pos := cube.Pos{0, 10, 0}
+
+		tx.SetBlock(pos, Glowstone{}, nil)
+		if y := tx.HighestLightBlocker(pos.X(), pos.Z()); y != pos.Y() {
+			return fmt.Errorf("highest light blocker after placing glowstone = %d, want %d", y, pos.Y())
+		}
+		return nil
+	})
+}
+
+func TestUnlitRedstoneTorchStillShapesDustConnection(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		wirePos := cube.Pos{0, 1, 0}
+		torchPos := wirePos.Side(cube.FaceEast)
+		notePos := wirePos.Side(cube.FaceNorth)
+
+		tx.SetBlock(torchPos, RedstoneTorch{Facing: cube.FaceDown}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(wirePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		Note{}.RedstoneUpdate(notePos, tx)
+		if note := tx.Block(notePos).(Note); note.Powered {
+			return fmt.Errorf("dust powered perpendicular receiver despite being shaped by unlit torch")
+		}
+		return nil
+	})
+}
+
+func TestRedstoneWireShapeOnlyNeighbourUpdatePropagates(t *testing.T) {
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		wirePos := cube.Pos{0, 1, 0}
+		supportPos := wirePos.Side(cube.FaceDown)
+		sourcePos := wirePos.Side(cube.FaceSouth)
+		torchPos := wirePos.Side(cube.FaceEast)
+		notePos := wirePos.Side(cube.FaceNorth)
+
+		tx.SetBlock(supportPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(sourcePos, RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(wirePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		Note{}.RedstoneUpdate(notePos, tx)
+		if note := tx.Block(notePos).(Note); !note.Powered {
+			return fmt.Errorf("note block was not powered before dust shape changed")
+		}
+
+		tx.SetBlock(torchPos, RedstoneTorch{Facing: cube.FaceDown}, &world.SetOpts{DisableBlockUpdates: true})
+		RedstoneWire{Power: 15}.NeighbourUpdateTick(wirePos, torchPos, tx)
+		if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 15 {
+			return fmt.Errorf("redstone wire power = %d, want 15", wire.Power)
+		}
+		if note := tx.Block(notePos).(Note); note.Powered {
+			return fmt.Errorf("note block stayed powered after dust shape changed")
+		}
+		return nil
+	})
+}
+
+func TestRedstoneWireStepsDownGlassButNotSlabs(t *testing.T) {
+	t.Run("stone", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			wirePos := cube.Pos{0, 1, 0}
+			sidePos := wirePos.Side(cube.FaceEast)
+			sourcePos := sidePos.Side(cube.FaceUp)
+
+			tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sidePos, Stone{}, nil)
+			tx.SetBlock(sourcePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sourcePos.Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			RedstoneWire{}.RedstoneUpdate(wirePos, tx)
+			if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 14 {
+				return fmt.Errorf("redstone wire below stone step-down = %d, want 14", wire.Power)
+			}
+			return nil
+		})
+	})
+
+	t.Run("glass", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			wirePos := cube.Pos{0, 1, 0}
+			sidePos := wirePos.Side(cube.FaceEast)
+			sourcePos := sidePos.Side(cube.FaceUp)
+
+			tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sidePos, Glass{}, nil)
+			tx.SetBlock(sourcePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sourcePos.Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			RedstoneWire{}.RedstoneUpdate(wirePos, tx)
+			if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 14 {
+				return fmt.Errorf("redstone wire below glass step-down = %d, want 14", wire.Power)
+			}
+			return nil
+		})
+	})
+
+	t.Run("glass spiral", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			a := func(y int) cube.Pos { return cube.Pos{0, y, 0} }
+			b := func(y int) cube.Pos { return cube.Pos{1, y, 0} }
+			wires := []cube.Pos{b(4), a(3), b(2), a(1)}
+
+			for _, pos := range []cube.Pos{a(4), a(2), b(3), b(1)} {
+				tx.SetBlock(pos, Glass{}, nil)
+			}
+			tx.SetBlock(a(0), Stone{}, nil)
+			tx.SetBlock(wires[0], RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(wires[0].Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+			for _, pos := range wires[1:] {
+				tx.SetBlock(pos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			}
+
+			for i, pos := range wires[1:] {
+				RedstoneWire{}.RedstoneUpdate(pos, tx)
+				want := 14 - i
+				if wire := tx.Block(pos).(RedstoneWire); wire.Power != want {
+					return fmt.Errorf("wire %d in glass spiral = %d, want %d", i+1, wire.Power, want)
+				}
+			}
+			return nil
+		})
+	})
+
+	t.Run("glass spiral upward", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			a := func(y int) cube.Pos { return cube.Pos{0, y, 0} }
+			b := func(y int) cube.Pos { return cube.Pos{1, y, 0} }
+			wires := []cube.Pos{a(1), b(2), a(3), b(4)}
+
+			for _, pos := range []cube.Pos{a(0), a(2), b(1), b(3)} {
+				tx.SetBlock(pos, Glass{}, nil)
+			}
+			tx.SetBlock(wires[0], RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(wires[0].Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+			for _, pos := range wires[1:] {
+				tx.SetBlock(pos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			}
+
+			updateStrongRedstone(wires[0], tx)
+			for i, pos := range wires {
+				want := 15 - i
+				if wire := tx.Block(pos).(RedstoneWire); wire.Power != want {
+					return fmt.Errorf("wire %d in upward glass spiral = %d, want %d", i, wire.Power, want)
+				}
+			}
+			return nil
+		})
+	})
+
+	t.Run("double slab", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			wirePos := cube.Pos{0, 1, 0}
+			sidePos := wirePos.Side(cube.FaceEast)
+			sourcePos := sidePos.Side(cube.FaceUp)
+
+			tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sidePos, Slab{Block: Stone{}, Double: true}, nil)
+			tx.SetBlock(sourcePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sourcePos.Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			RedstoneWire{}.RedstoneUpdate(wirePos, tx)
+			if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 14 {
+				return fmt.Errorf("redstone wire below double slab step-down = %d, want 14", wire.Power)
+			}
+			return nil
+		})
+	})
+
+	t.Run("slab", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			wirePos := cube.Pos{0, 1, 0}
+			sidePos := wirePos.Side(cube.FaceEast)
+			sourcePos := sidePos.Side(cube.FaceUp)
+
+			tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sidePos, Slab{Block: Stone{}, Top: true}, nil)
+			tx.SetBlock(sourcePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sourcePos.Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			RedstoneWire{}.RedstoneUpdate(wirePos, tx)
+			if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 0 {
+				return fmt.Errorf("redstone wire below slab step-down = %d, want 0", wire.Power)
+			}
+			return nil
+		})
+	})
+
+	t.Run("stairs", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			wirePos := cube.Pos{0, 1, 0}
+			sidePos := wirePos.Side(cube.FaceEast)
+			sourcePos := sidePos.Side(cube.FaceUp)
+
+			tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sidePos, Stairs{Block: Stone{}, Facing: cube.North, UpsideDown: true}, nil)
+			tx.SetBlock(sourcePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sourcePos.Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			RedstoneWire{}.RedstoneUpdate(wirePos, tx)
+			if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 0 {
+				return fmt.Errorf("redstone wire below stairs step-down = %d, want 0", wire.Power)
+			}
+			return nil
+		})
+	})
+
+	t.Run("hopper", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			wirePos := cube.Pos{0, 1, 0}
+			sidePos := wirePos.Side(cube.FaceEast)
+			sourcePos := sidePos.Side(cube.FaceUp)
+
+			tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sidePos, Hopper{Facing: cube.FaceDown}, nil)
+			tx.SetBlock(sourcePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sourcePos.Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			RedstoneWire{}.RedstoneUpdate(wirePos, tx)
+			if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 0 {
+				return fmt.Errorf("redstone wire below hopper step-down = %d, want 0", wire.Power)
+			}
+			return nil
+		})
+	})
+
+	t.Run("glowstone", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			wirePos := cube.Pos{0, 1, 0}
+			sidePos := wirePos.Side(cube.FaceEast)
+			sourcePos := sidePos.Side(cube.FaceUp)
+
+			tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sidePos, Glowstone{}, nil)
+			tx.SetBlock(sourcePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sourcePos.Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			RedstoneWire{}.RedstoneUpdate(wirePos, tx)
+			if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 0 {
+				return fmt.Errorf("redstone wire below glowstone step-down = %d, want 0", wire.Power)
+			}
+			return nil
+		})
+	})
+
+	t.Run("sea lantern", func(t *testing.T) {
+		testRedstoneTx(t, func(tx *world.Tx) error {
+			wirePos := cube.Pos{0, 1, 0}
+			sidePos := wirePos.Side(cube.FaceEast)
+			sourcePos := sidePos.Side(cube.FaceUp)
+
+			tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sidePos, SeaLantern{}, nil)
+			tx.SetBlock(sourcePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(sourcePos.Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			RedstoneWire{}.RedstoneUpdate(wirePos, tx)
+			if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 14 {
+				return fmt.Errorf("redstone wire below sea lantern step-down = %d, want 14", wire.Power)
+			}
+			return nil
+		})
+	})
+}
+
+func TestRedstoneWireDirectAndNetworkUpdatesMatch(t *testing.T) {
+	buildSpiral := func(tx *world.Tx) []cube.Pos {
+		a := func(y int) cube.Pos { return cube.Pos{0, y, 0} }
+		b := func(y int) cube.Pos { return cube.Pos{1, y, 0} }
+		wires := []cube.Pos{a(1), b(2), a(3), b(4)}
+
+		for _, pos := range []cube.Pos{a(0), a(2), b(1), b(3)} {
+			tx.SetBlock(pos, Glass{}, nil)
+		}
+		tx.SetBlock(wires[0], RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(wires[0].Side(cube.FaceSouth), RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+		for _, pos := range wires[1:] {
+			tx.SetBlock(pos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+		}
+		return wires
+	}
+	readPowers := func(tx *world.Tx, wires []cube.Pos) []int {
+		powers := make([]int, len(wires))
+		for i, pos := range wires {
+			powers[i] = tx.Block(pos).(RedstoneWire).Power
+		}
+		return powers
+	}
+
+	var directPowers []int
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		wires := buildSpiral(tx)
+		for _, pos := range wires[1:] {
+			RedstoneWire{}.RedstoneUpdate(pos, tx)
+		}
+		directPowers = readPowers(tx, wires)
+		return nil
+	})
+
+	testRedstoneTx(t, func(tx *world.Tx) error {
+		wires := buildSpiral(tx)
+		updateStrongRedstone(wires[0], tx)
+		networkPowers := readPowers(tx, wires)
+		if len(networkPowers) != len(directPowers) {
+			return fmt.Errorf("network wire count = %d, want %d", len(networkPowers), len(directPowers))
+		}
+		for i := range networkPowers {
+			if networkPowers[i] != directPowers[i] {
+				return fmt.Errorf("wire %d power mismatch: direct=%d network=%d", i, directPowers[i], networkPowers[i])
+			}
+		}
+		return nil
+	})
+}

--- a/server/block/redstone_torch_test.go
+++ b/server/block/redstone_torch_test.go
@@ -1,0 +1,107 @@
+package block
+
+import (
+	"fmt"
+	"testing"
+	_ "unsafe"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+//go:linkname finaliseBlockRegistryForRedstoneTorch github.com/df-mc/dragonfly/server/world.finaliseBlockRegistry
+func finaliseBlockRegistryForRedstoneTorch()
+
+func init() {
+	finaliseBlockRegistryForRedstoneTorch()
+}
+
+func testRedstoneTorchTx(t *testing.T, f func(tx *world.Tx) error) {
+	t.Helper()
+
+	w := world.New()
+	var txErr error
+	<-w.Exec(func(tx *world.Tx) {
+		txErr = f(tx)
+	})
+	if err := w.Close(); err != nil {
+		t.Fatalf("close world: %v", err)
+	}
+	if txErr != nil {
+		t.Fatal(txErr)
+	}
+}
+
+func TestRedstoneTorchUnpowersReceiversBehindStronglyPoweredBlock(t *testing.T) {
+	testRedstoneTorchTx(t, func(tx *world.Tx) error {
+		torchPos := cube.Pos{0, 1, 0}
+		stonePos := torchPos.Side(cube.FaceUp)
+		notePos := stonePos.Side(cube.FaceEast)
+
+		tx.SetBlock(torchPos, RedstoneTorch{Facing: cube.FaceDown, Lit: true}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(stonePos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		updateTorchRedstone(torchPos, tx)
+		if note := tx.Block(notePos).(Note); !note.Powered {
+			return fmt.Errorf("note block was not powered through strongly powered block")
+		}
+
+		tx.SetBlock(torchPos, RedstoneTorch{Facing: cube.FaceDown}, &world.SetOpts{DisableBlockUpdates: true})
+		updateTorchRedstone(torchPos, tx)
+		if note := tx.Block(notePos).(Note); note.Powered {
+			return fmt.Errorf("note block stayed powered after torch stopped strongly powering block")
+		}
+		return nil
+	})
+}
+
+func TestExternallyClockedRedstoneTorchDoesNotBurnOut(t *testing.T) {
+	testRedstoneTorchTx(t, func(tx *world.Tx) error {
+		torchPos := cube.Pos{1, 1, 0}
+		inputPos := torchPos.Side(cube.FaceWest)
+
+		tx.SetBlock(inputPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(torchPos, RedstoneTorch{Facing: cube.FaceWest, Lit: true}, &world.SetOpts{DisableBlockUpdates: true})
+
+		for i := 0; i < 10; i++ {
+			tx.SetBlock(inputPos, RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.Block(torchPos).(RedstoneTorch).ScheduledTick(torchPos, tx, nil)
+			if torch := tx.Block(torchPos).(RedstoneTorch); torch.Lit {
+				return fmt.Errorf("torch stayed lit after powered external input on cycle %d", i)
+			}
+
+			tx.SetBlock(inputPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.Block(torchPos).(RedstoneTorch).ScheduledTick(torchPos, tx, nil)
+			if torch := tx.Block(torchPos).(RedstoneTorch); !torch.Lit {
+				return fmt.Errorf("torch burned out after unpowered external input on cycle %d", i)
+			}
+		}
+		return nil
+	})
+}
+
+func TestBurnedOutRedstoneTorchRelightsOnNeighbourBlockUpdate(t *testing.T) {
+	testRedstoneTorchTx(t, func(tx *world.Tx) error {
+		supportPos := cube.Pos{0, 1, 0}
+		torchPos := supportPos.Side(cube.FaceEast)
+		changedPos := torchPos.Side(cube.FaceUp)
+
+		tx.SetBlock(supportPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(torchPos, RedstoneTorch{Facing: cube.FaceWest}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(changedPos, Air{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.Redstone().BurnOutTorch(torchPos)
+
+		tx.SetBlock(changedPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.Block(torchPos).(RedstoneTorch).NeighbourUpdateTick(torchPos, changedPos, tx)
+
+		torch := tx.Block(torchPos).(RedstoneTorch)
+		if !torch.Lit {
+			return fmt.Errorf("burned out torch did not relight after neighbour block update")
+		}
+		if burnedOut, _ := tx.Redstone().TorchBurnoutStatus(torchPos, tx.CurrentTick()); burnedOut {
+			return fmt.Errorf("burnout state was not cleared after neighbour block update recovery")
+		}
+		return nil
+	})
+}

--- a/server/block/redstone_wire_break_test.go
+++ b/server/block/redstone_wire_break_test.go
@@ -1,0 +1,229 @@
+package block
+
+import (
+	"fmt"
+	"testing"
+	_ "unsafe"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/event"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+//go:linkname finaliseBlockRegistryForRedstoneWireBreak github.com/df-mc/dragonfly/server/world.finaliseBlockRegistry
+func finaliseBlockRegistryForRedstoneWireBreak()
+
+func init() {
+	finaliseBlockRegistryForRedstoneWireBreak()
+}
+
+func testRedstoneWireBreakTx(t *testing.T, f func(tx *world.Tx) error) {
+	t.Helper()
+
+	w := world.Config{Entities: testRedstoneWireBreakEntityRegistry}.New()
+	var txErr error
+	<-w.Exec(func(tx *world.Tx) {
+		txErr = f(tx)
+	})
+	if err := w.Close(); err != nil {
+		t.Fatalf("close world: %v", err)
+	}
+	if txErr != nil {
+		t.Fatal(txErr)
+	}
+}
+
+var testRedstoneWireBreakEntityRegistry = world.EntityRegistryConfig{
+	Item: func(opts world.EntitySpawnOpts, _ any) *world.EntityHandle {
+		return opts.New(testRedstoneWireBreakEntityType{}, testRedstoneWireBreakEntityConfig{})
+	},
+}.New(nil)
+
+type testRedstoneWireBreakEntityConfig struct{}
+
+func (testRedstoneWireBreakEntityConfig) Apply(*world.EntityData) {}
+
+type testRedstoneWireBreakEntityType struct{}
+
+func (testRedstoneWireBreakEntityType) Open(_ *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
+	return testRedstoneWireBreakEntity{handle: handle, pos: data.Pos, rot: data.Rot}
+}
+
+func (testRedstoneWireBreakEntityType) EncodeEntity() string { return "test:item" }
+
+func (testRedstoneWireBreakEntityType) BBox(world.Entity) cube.BBox { return cube.BBox{} }
+
+func (testRedstoneWireBreakEntityType) DecodeNBT(map[string]any, *world.EntityData) {}
+
+func (testRedstoneWireBreakEntityType) EncodeNBT(*world.EntityData) map[string]any { return nil }
+
+type testRedstoneWireBreakEntity struct {
+	handle *world.EntityHandle
+	pos    mgl64.Vec3
+	rot    cube.Rotation
+}
+
+func (e testRedstoneWireBreakEntity) Close() error { return nil }
+
+func (e testRedstoneWireBreakEntity) H() *world.EntityHandle { return e.handle }
+
+func (e testRedstoneWireBreakEntity) Position() mgl64.Vec3 { return e.pos }
+
+func (e testRedstoneWireBreakEntity) Rotation() cube.Rotation { return e.rot }
+
+func TestUnsupportedRedstoneWireUnpowersHorizontalMechanisms(t *testing.T) {
+	testRedstoneWireBreakTx(t, func(tx *world.Tx) error {
+		supportPos := cube.Pos{0, 0, 0}
+		wirePos := supportPos.Side(cube.FaceUp)
+		notePos := wirePos.Side(cube.FaceEast)
+
+		tx.SetBlock(supportPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(wirePos, RedstoneWire{Power: 15}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		Note{}.RedstoneUpdate(notePos, tx)
+		if note := tx.Block(notePos).(Note); !note.Powered {
+			return fmt.Errorf("note block next to powered dust was not powered before support broke")
+		}
+
+		tx.SetBlock(supportPos, nil, &world.SetOpts{DisableBlockUpdates: true})
+		RedstoneWire{Power: 15}.NeighbourUpdateTick(wirePos, supportPos, tx)
+		if note := tx.Block(notePos).(Note); note.Powered {
+			return fmt.Errorf("note block stayed powered after unsupported dust broke")
+		}
+		return nil
+	})
+}
+
+func TestRedstoneWireNeighbourUpdateUsesCancellableHandler(t *testing.T) {
+	testRedstoneWireBreakTx(t, func(tx *world.Tx) error {
+		supportPos := cube.Pos{0, 0, 0}
+		wirePos := supportPos.Side(cube.FaceUp)
+		sourcePos := wirePos.Side(cube.FaceEast)
+		handler := &testRedstoneUpdateHandler{cancel: map[cube.Pos]bool{wirePos: true}}
+		tx.World().Handle(handler)
+
+		tx.SetBlock(supportPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(sourcePos, RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		RedstoneWire{}.NeighbourUpdateTick(wirePos, sourcePos, tx)
+		if !handler.called[wirePos] {
+			return fmt.Errorf("redstone handler was not called for dust neighbour update")
+		}
+		if wire := tx.Block(wirePos).(RedstoneWire); wire.Power != 0 {
+			return fmt.Errorf("cancelled dust neighbour update changed wire power to %d", wire.Power)
+		}
+		return nil
+	})
+}
+
+func TestRedstoneWireNetworkUsesCancellableHandler(t *testing.T) {
+	testRedstoneWireBreakTx(t, func(tx *world.Tx) error {
+		supportPos := cube.Pos{0, 0, 0}
+		wirePos := supportPos.Side(cube.FaceUp)
+		nextWirePos := wirePos.Side(cube.FaceWest)
+		sourcePos := wirePos.Side(cube.FaceEast)
+		handler := &testRedstoneUpdateHandler{cancel: map[cube.Pos]bool{nextWirePos: true}}
+		tx.World().Handle(handler)
+
+		tx.SetBlock(supportPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(supportPos.Side(cube.FaceWest), Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(wirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(nextWirePos, RedstoneWire{}, &world.SetOpts{DisableBlockUpdates: true})
+		tx.SetBlock(sourcePos, RedstoneBlock{}, &world.SetOpts{DisableBlockUpdates: true})
+
+		updateRedstone(wirePos, tx)
+		if !handler.called[nextWirePos] {
+			return fmt.Errorf("redstone handler was not called for network dust update")
+		}
+		if wire := tx.Block(nextWirePos).(RedstoneWire); wire.Power != 0 {
+			return fmt.Errorf("cancelled network dust update changed wire power to %d", wire.Power)
+		}
+		return nil
+	})
+}
+
+func TestLeverDetachDoesNotDuplicateBreakRedstoneUpdates(t *testing.T) {
+	noteUpdateCount := func(detach bool) (int, error) {
+		leverPos := cube.Pos{0, 1, 0}
+		supportPos := leverPos.Side(cube.FaceWest)
+		notePos := leverPos.Side(cube.FaceEast)
+		handler := &testRedstoneUpdateHandler{}
+
+		err := runLeverBreakTx(func(tx *world.Tx) error {
+			tx.World().Handle(handler)
+
+			tx.SetBlock(supportPos, Stone{}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(leverPos, Lever{Powered: true, Facing: cube.FaceEast}, &world.SetOpts{DisableBlockUpdates: true})
+			tx.SetBlock(notePos, Note{}, &world.SetOpts{DisableBlockUpdates: true})
+
+			Note{}.RedstoneUpdate(notePos, tx)
+			if note := tx.Block(notePos).(Note); !note.Powered {
+				return fmt.Errorf("note block was not powered before lever broke")
+			}
+
+			lever := Lever{Powered: true, Facing: cube.FaceEast}
+			tx.SetBlock(supportPos, nil, &world.SetOpts{DisableBlockUpdates: true})
+			if detach {
+				lever.NeighbourUpdateTick(leverPos, supportPos, tx)
+			} else {
+				breakBlock(lever, leverPos, tx)
+			}
+			if note := tx.Block(notePos).(Note); note.Powered {
+				return fmt.Errorf("note block stayed powered after lever broke")
+			}
+			return nil
+		})
+		return handler.counts[notePos], err
+	}
+
+	directBreakCount, err := noteUpdateCount(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	detachCount, err := noteUpdateCount(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detachCount != directBreakCount {
+		t.Fatalf("lever detach note block redstone update count = %d, want direct break count %d", detachCount, directBreakCount)
+	}
+}
+
+func runLeverBreakTx(f func(tx *world.Tx) error) error {
+	w := world.Config{Entities: testRedstoneWireBreakEntityRegistry}.New()
+	var txErr error
+	<-w.Exec(func(tx *world.Tx) {
+		txErr = f(tx)
+	})
+	if err := w.Close(); err != nil {
+		if txErr != nil {
+			return fmt.Errorf("%v; close world: %w", txErr, err)
+		}
+		return fmt.Errorf("close world: %w", err)
+	}
+	return txErr
+}
+
+type testRedstoneUpdateHandler struct {
+	world.NopHandler
+	called map[cube.Pos]bool
+	counts map[cube.Pos]int
+	cancel map[cube.Pos]bool
+}
+
+func (h *testRedstoneUpdateHandler) HandleRedstoneUpdate(ctx *event.Context[*world.Tx], pos cube.Pos) {
+	if h.called == nil {
+		h.called = make(map[cube.Pos]bool)
+	}
+	if h.counts == nil {
+		h.counts = make(map[cube.Pos]int)
+	}
+	h.called[pos] = true
+	h.counts[pos]++
+	if h.cancel[pos] {
+		ctx.Cancel()
+	}
+}


### PR DESCRIPTION
## Summary
- Adds Go tests under `server/block/` that exercise the recent batch of redstone fixes against a real `world.Tx`, locking in behavior so future refactors don't silently regress it.
- Coverage:
  - `note_redstone_test.go` — powered note block propagating updates to adjacent note blocks.
  - `redstone_regression_test.go` — unconnected dust powering adjacent mechanisms, solid-block propagation through stone, redstone block ≠ strong source through solid blocks, dust step-down through glass/slabs/stairs/hoppers/glowstone/sea lantern, and direct vs network update parity.
  - `redstone_torch_test.go` — torch unpowering receivers behind a strongly powered block.
  - `redstone_wire_break_test.go` — `RedstoneUpdate` handler is invoked through both direct and network paths and respects `event.Cancel()`.

## Test plan
- [x] `go test ./server/block/ -run 'TestRedstone|TestPowered|TestUnconnected|TestNote' -count=1` (12 passing)
- [x] `go vet ./server/block/`

---

## Missing redstone features (post-merge roadmap)

Once #1095 lands, this is what's left between dragonfly and a vanilla-Bedrock-equivalent redstone surface. Impact = how foundational the feature is to typical builds; Difficulty = engineering cost in dragonfly given current tick/scheduling primitives.

### Core wiring & logic
| Feature | Impact | Difficulty |
| --- | --- | --- |
| Redstone repeater (delay 1–4t, locking) | High | High |
| Redstone comparator (compare/subtract, container read) | High | High |
| Observer (block-update detector pulse) | High | Medium |
| Scheduled-tick infrastructure tightening (for repeaters/comparators/pistons) | High | High |

### Power sources
| Feature | Impact | Difficulty |
| --- | --- | --- |
| Buttons (wood, stone, polished, mangrove etc.) | High | Low |
| Pressure plates (stone, wooden variants) | High | Low |
| Weighted pressure plates (light/heavy, analog 1–15) | Medium | Low |
| Trapped chest (powers from viewer count) | Medium | Low |
| Daylight detector (regular + inverted) | Medium | Medium |
| Target block (analog output on projectile hit) | Medium | Low |
| Tripwire + tripwire hook | Low | Medium |
| Lectern (comparator output from page) | Low | Low |
| Lightning rod (pulse on strike) | Low | Low |
| Sculk sensor / calibrated sculk sensor | Low | High |

### Mechanism components
| Feature | Impact | Difficulty |
| --- | --- | --- |
| Piston / sticky piston (push, retract, 12-block limit, immovable list) | High | High |
| Dispenser (per-item behaviors: arrows, water, fire charges, eggs, armor) | High | High |
| Dropper | Medium | Medium |
| TNT (redstone priming + fuse) | High | Medium |
| Redstone lamp | Medium | Low |
| Crafter (auto-craft on pulse) | Medium | High |
| Copper bulb (toggle-on-pulse + oxidation/wax states) | Low | Medium |
| Bell (rings on power) | Low | Low |

### Doors / movement blocks
| Feature | Impact | Difficulty |
| --- | --- | --- |
| Iron door (redstone-only open) | Medium | Low |
| Iron trapdoor (redstone-only open) | Medium | Low |
| Fence gate (open on power) | Medium | Low |
| Trapdoors (wooden, power-driven) | Medium | Low |

### Rails
| Feature | Impact | Difficulty |
| --- | --- | --- |
| Powered rail (accelerate / brake) | Medium | Medium |
| Detector rail (cart-presence pulse) | Medium | Medium |
| Activator rail (eject riders, prime TNT cart) | Low | Medium |

### Containers / interaction
| Feature | Impact | Difficulty |
| --- | --- | --- |
| Hopper locking when powered | Medium | Low |
| Comparator container reading (chest, hopper, barrel, brewing stand, jukebox, cake, composter, beehive) | High | Medium |

### Bedrock parity polish
| Feature | Impact | Difficulty |
| --- | --- | --- |
| `RedstonePowerRelayer` audit of remaining mis-marked transparent blocks (TODO from 47106260) | Medium | Low |
| 1-tick repeater / instant-repeater behavior parity | Low | Medium |
| Update-order determinism vs Bedrock RNG ordering | Low | High |

🤖 Generated with [Claude Code](https://claude.com/claude-code)